### PR TITLE
Add .bowerrc, change react.min.js location

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory" : "client/bower_components"
+}

--- a/client/index.html
+++ b/client/index.html
@@ -2,8 +2,8 @@
 <html>
 <head>
   <title>Vask</title>
-  <script src="./build/react.min.js"></script>
-  <script src="./build/JSXTransformer.js"></script>
+  <script src="../bower_components/react/react.min.js"></script>
+  <script src="../bower_components/react/JSXTransformer.js"></script>
 </head>
 <body>
   <div class="vask"></div>


### PR DESCRIPTION
Made bower_components/react/react.min.js capable of being referenced. Now all you have to do is type "bower install" and then when you run the server, everything works. The .bowerrc file puts the bower_components file into the client directory so it can be referenced.
